### PR TITLE
Added news about ASP.NET AJAX Control Toolkit v19.1.0

### DIFF
--- a/2019/07.md
+++ b/2019/07.md
@@ -143,7 +143,7 @@ For more great information be sure to tune in and follow Prism's maintainers
   * [Watch live on Twitch](https://twitch.tv/dansiegel)
   * [Follow on Twitter](https://twitter.com/DanJSiegel)
 
-## [Akka.NET v1.3.14 Released](https://github.com/akkadotnet/akka.net/releases/tag/1.3.14)
+### [Akka.NET v1.3.14 Released](https://github.com/akkadotnet/akka.net/releases/tag/1.3.14)
 
 **Maintenance Release for Akka.NET 1.3**
 You know what? We're going to stop promising that _this_ is the last 1.3.x release, because even though we've said that twice... We now have _another_ 1.3.x release. 
@@ -161,5 +161,38 @@ You know what? We're going to stop promising that _this_ is the last 1.3.x relea
 To [see the full set of changes for Akka.NET v1.3.14, click here](https://github.com/akkadotnet/akka.net/pull/3869).
 
 [Follow Akka.NET on Twitter](https://twitter.com/AkkaDotNet) if you're interested in receiving more updates from the project.
+
+### [ASP.NET AJAX Control Toolkit v19.1.0 - Now Available](https://community.devexpress.com/blogs/aspnet/archive/2019/07/03/asp-net-ajax-control-toolkit-v19-1-0-now-available.aspx)
+
+A few years ago, we took over maintenance and guidance for the ASP.NET AJAX Control Toolkit project. Please refer to this [blog post](https://community.devexpress.com/blogs/aspnet/archive/2014/09/22/ajax-control-toolkit-devexpress-offer.aspx) for more information on the project and why we stepped in to assist.
+
+![DevExpress - ASP.NET AJAX Control Toolkit](https://community.devexpress.com/blogs/aspnet/ACT/AJAX-Control-Toolkit-1x3.png).
+
+As part of our ongoing commitment to the project, we’ve released an update ([ASP.NET AJAX Control Toolkit v19.1.0](https://devexpress.com/act)) to address the following issues.
+
+#### Improvements
+
+- Visual Studio 2019 Support
+- Security hardening: HTML-encode file names in `AjaxFileUpload` ([#483](https://github.com/DevExpress/AjaxControlToolkit/pull/483))
+
+#### Resolved Issues
+
+- `AutoCompleteExtender`: the `TextChanged` event is not fired in Edge ([#458](https://github.com/DevExpress/AjaxControlToolkit/issues/458))
+- `Rating`: The `raise_mouseOver` method has an invalid argument name ([#461](https://github.com/DevExpress/AjaxControlToolkit/issues/461))
+- `AsyncFileUpload` changes the frame target to `_top` ([#466](https://github.com/DevExpress/AjaxControlToolkit/issues/466))
+- `HtmlEditorExtender` unconditionally removes tags with data URLs ([#467](https://github.com/DevExpress/AjaxControlToolkit/issues/467))
+- NRE in `IsLocalizationEnabled()` within a `PageAsyncTask` ([#486](https://github.com/DevExpress/AjaxControlToolkit/issues/486))
+
+#### Ready to Upgrade?
+
+To update the ASP.NET AJAX Control Toolkit, please download our most recent installer using the link below.
+
+<a href="https://go.devexpress.com/AjaxControlToolkit_Website_Download.aspx" class="Button Orange">Download</a>
+
+Or, if you prefer, use Nuget:
+
+<a href="http://www.nuget.org/packages/AjaxControlToolkit/" target="_blank">ASP.NET AJAX Control Toolkit Nuget package</a>
+
+As always, we welcome your feedback. Please share your thoughts on this update via [GitHub](https://github.com/DevExpress/AjaxControlToolkit/issues).
 
 ## Meetups


### PR DESCRIPTION
Added news about the ASP.NET AJAX Control Toolkit v19.1.0 release.

### Thank you for submitting news for the newsletter.

Please make sure your submission follows the guidelines noted here: https://github.com/dotnet-foundation/newsletter#submission