### PR TITLE
Avoid using US-centric date format

### DIFF
--- a/2020/01.md
+++ b/2020/01.md
@@ -10,7 +10,7 @@ As always, these are available both on our blog and via e-mail: [Sign up to get 
 
 ## Foundation Updates
 
-The board has decided to hold its meetings on the third Thursday of every month. The next board meeting is scheduled for 2/20. At the last meeting, the board discussed the current action group structure and decided to narrow focus. The new committees will be:
+The board has decided to hold its meetings on the third Thursday of every month. The next board meeting is scheduled for February 20th. At the last meeting, the board discussed the current action group structure and decided to narrow focus. The new committees will be:
 
 * Membership - processing new member applications and setting membership policies
 * Projects - project support requests and processing new project applications


### PR DESCRIPTION
Particularly when it doesn't contain a year, but the year is the same as the day-of-month.

I'd generally suggest we either use words ("February 20th") or ISO-8601 dates ("2020-02-20"). My experience with working in design docs with US colleagues is that either of these formats will cause significantly less discombobulation (at least for me).
